### PR TITLE
Removing @ and # prefix from callback response

### DIFF
--- a/src/main/java/com/carrotcreative/socialui/util/SocialMovementMethod.java
+++ b/src/main/java/com/carrotcreative/socialui/util/SocialMovementMethod.java
@@ -56,11 +56,13 @@ public class SocialMovementMethod extends LinkMovementMethod {
         if(url.startsWith(SOCIAL_UI_HASHTAG_SCHEME))
         {
             String hashtag = url.replaceFirst(SOCIAL_UI_HASHTAG_SCHEME, "");
+            hashtag = hashtag.replaceFirst(".*#", "");
             mHandler.handleHashtag(hashtag);
         }
         else if(url.startsWith(SOCIAL_UI_MENTION_SCHEME))
         {
             String mention = url.replaceFirst(SOCIAL_UI_MENTION_SCHEME, "");
+            mention = mention.replaceFirst(".*@", "");
             mHandler.handleMention(mention);
         }
         else


### PR DESCRIPTION
The callbacks were responding with responses like this (`_` as a space):

`_#hashtag`
`#hashtag`
`@mention`
`_@mention`

(depending on if there was a space before the occurrence of the string).

Simply removing the `#` and `@` from the response.  This was fluff information that likely had to be parsed out anyways, so removing it at library level.
